### PR TITLE
Add '01 (C1)' option to English and Deutsch courses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ap-education",
-  "version": "1.0.64.04",
+  "version": "1.0.64.05",
   "private": true,
   "homepage": "https://academy.ap.education/",
   "dependencies": {

--- a/src/pages/Streams/TimeTableAdminPanel/TimeTableAdminPanel.jsx
+++ b/src/pages/Streams/TimeTableAdminPanel/TimeTableAdminPanel.jsx
@@ -239,6 +239,10 @@ const TimeTableAdminPanel = () => {
 
   const courseEnglishOptions = [
     {
+      label: '01 (C1)',
+      value: '01',
+    },
+    {
       label: '10 (Спікінги)',
       value: '10',
     },
@@ -361,6 +365,10 @@ const TimeTableAdminPanel = () => {
   ];
 
   const courseDeutschOptions = [
+    {
+      label: '01 (C1)',
+      value: '01',
+    },
     {
       label: '10 (Спікінги)',
       value: '10',


### PR DESCRIPTION
Added a new '01 (C1)' option to both courseEnglishOptions and courseDeutschOptions arrays in TimeTableAdminPanel