### PR TITLE
Fix admin teacher table rendering condition

### DIFF
--- a/src/pages/Streams/TeacherAdminPanel/TeacherControlPageDe.jsx
+++ b/src/pages/Streams/TeacherAdminPanel/TeacherControlPageDe.jsx
@@ -170,7 +170,7 @@ const TeacherControlPageDe = () => {
           </Formik>
         )}
 
-        {isUserAdmin && teachers.length && (
+        {isUserAdmin && teachers.length > 0 && (
           <TeacherTable>
             <UserDBCaption>
               Список тічерів та їх відгуків (німецька) за

--- a/src/pages/Streams/TeacherAdminPanel/TeacherControlPageEn.jsx
+++ b/src/pages/Streams/TeacherAdminPanel/TeacherControlPageEn.jsx
@@ -170,7 +170,7 @@ const yearOptions = [
           </Formik>
         )}
 
-        {isUserAdmin && teachers.length && (
+        {isUserAdmin && teachers.length > 0 && (
           <TeacherTable>
             <UserDBCaption>
               Список тічерів та їх відгуків (англійська) за

--- a/src/pages/Streams/TeacherAdminPanel/TeacherControlPagePl.jsx
+++ b/src/pages/Streams/TeacherAdminPanel/TeacherControlPagePl.jsx
@@ -170,7 +170,7 @@ const TeacherControlPagePl = () => {
           </Formik>
         )}
 
-        {isUserAdmin && teachers.length && (
+        {isUserAdmin && teachers.length > 0 && (
           <TeacherTable>
             <UserDBCaption>
               Список тічерів та їх відгуків (польська) за


### PR DESCRIPTION
Update the condition to render the teacher table for admins to explicitly check that teachers.length is greater than 0, ensuring the table only appears when there are teachers in the list.