### PR TITLE
Add teacher name filter to appointments admin panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ap-education",
-  "version": "1.0.64.17",
+  "version": "1.0.64.18",
   "private": true,
   "homepage": "https://academy.ap.education/",
   "dependencies": {

--- a/src/pages/Streams/AppointmentsAdminPanel/AppointmentsAdminPanel.styled.js
+++ b/src/pages/Streams/AppointmentsAdminPanel/AppointmentsAdminPanel.styled.js
@@ -16,6 +16,14 @@ export const AppointmentDBTable = styled(UserDBTable)`
   position: relative;
 `;
 
+export const TeacherFilterInput = styled.input`
+  width: 350px;
+  max-height: 38px;
+
+  padding: 10px;
+  border: 2px solid var(--main-color);
+`;
+
 export const CheckboxContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -28,7 +36,7 @@ export const AppointmentCaption = styled(UserDBCaption)`
   position: sticky;
   top: 0;
   z-index: 1;
-  height: 120px;
+  height: 175px;
 
   background: linear-gradient(#ffffff 75%, #ffffff80);
   padding: 12px;


### PR DESCRIPTION
Introduced a text input to filter teachers by name in the AppointmentsAdminPanel. Updated the table to display separate columns for pending, completed, and no-show appointments. Adjusted styles to accommodate the new filter input and increased the caption height.