### PR TITLE
Add trial appointments filter and course purchase info

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ap-education",
-  "version": "1.0.64.19",
+  "version": "1.0.64.20",
   "private": true,
   "homepage": "https://academy.ap.education/",
   "dependencies": {

--- a/src/pages/Streams/AppointmentsAdminPanel/AppointmentStudentModal.jsx
+++ b/src/pages/Streams/AppointmentsAdminPanel/AppointmentStudentModal.jsx
@@ -6,6 +6,7 @@ import {
   StudentAppointmentBox,
   StudentAppointmentList,
   StudentAppointmentListItem,
+  StudentCoursePurchased,
   StudentInfo,
   StudentInfoText,
   StudentInfoTextHighlight,
@@ -16,6 +17,7 @@ export const AppointmentStudentModal = ({
   closeStudentAppointments,
   teachers,
   chosenTeacher,
+  showTrialsOnly,
 }) => {
   const getStatusLabel = status => {
     switch (status) {
@@ -119,10 +121,69 @@ export const AppointmentStudentModal = ({
             }
           </StudentInfoTextHighlight>
         </StudentInfoText>
+        {showTrialsOnly && (
+          <>
+            <StudentInfoText>
+              Курс придбав(-ла):{' '}
+              <StudentInfoTextHighlight>
+                {studentAppointments.some(
+                  studentAppointment => studentAppointment.courseePurchaseDate
+                ) ? (
+                  <StudentCoursePurchased className="yes">Так</StudentCoursePurchased>
+                ) : (
+                  <StudentCoursePurchased className="no">Ні</StudentCoursePurchased>
+                )}
+              </StudentInfoTextHighlight>
+            </StudentInfoText>
+
+            {(() => {
+              const purchasedCourses = studentAppointments.filter(
+                studentAppointment => studentAppointment.leadPurchasedCourse
+              );
+
+              return purchasedCourses.length > 0 ? (
+                <>
+                  <StudentInfoText>
+                    Дата придбання:{' '}
+                    {purchasedCourses.map(appointment => (
+                      <StudentInfoTextHighlight>
+                        {new Date(appointment.courseePurchaseDate).toLocaleString(
+                          'uk-UA',
+                          {
+                            year: 'numeric',
+                            month: 'numeric',
+                            day: 'numeric',
+                            hour: '2-digit',
+                            minute: '2-digit',
+                          }
+                        )}
+                      </StudentInfoTextHighlight>
+                    ))}
+                  </StudentInfoText>
+                  <StudentInfoText>
+                    У викладача(-ів):{' '}
+                    {teachers
+                      .filter(teacher =>
+                        purchasedCourses
+                          .map(appointment => appointment.teacherId)
+                          .includes(String(teacher.altegioId))
+                      )
+                      .map(teacher => (
+                        <StudentInfoTextHighlight>
+                          {teacher.name}
+                        </StudentInfoTextHighlight>
+                      ))}
+                  </StudentInfoText>
+                </>
+              ) : null;
+            })()}
+          </>
+        )}
       </StudentInfo>
       <StudentAppointmentBox>
         <HeaderCellBody>
           <AppointmentSpan componentWidth="6em">ID Запису</AppointmentSpan>
+          <AppointmentSpan componentWidth="8em">Тип</AppointmentSpan>
           <AppointmentSpan componentWidth="15em">Дата і час запису</AppointmentSpan>
           <AppointmentSpan componentWidth="15em">Тічер</AppointmentSpan>
           <AppointmentSpan componentWidth="8em">Статус запису</AppointmentSpan>
@@ -138,6 +199,9 @@ export const AppointmentStudentModal = ({
                 >
                   <AppointmentSpan componentWidth="6em">
                     {appointment.appointmentId}
+                  </AppointmentSpan>
+                  <AppointmentSpan componentWidth="8em">
+                    {appointment.IsTrial ? 'Пробне' : 'Індивідуальне'}
                   </AppointmentSpan>
                   <AppointmentSpan componentWidth="15em">
                     {(() => {

--- a/src/pages/Streams/AppointmentsAdminPanel/AppointmentsAdminPanel.jsx
+++ b/src/pages/Streams/AppointmentsAdminPanel/AppointmentsAdminPanel.jsx
@@ -27,6 +27,7 @@ import {
   CheckboxInput,
   CheckboxLabel,
   HeaderCellBody,
+  PurchasedCourse,
   TeacherFilterInput,
 } from './AppointmentsAdminPanel.styled';
 import { AppointmentStudentModal } from './AppointmentStudentModal';
@@ -51,6 +52,7 @@ export const AppointmentsAdminPanel = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isUserAdmin, setIsUserAdmin] = useState(false);
   const [showDeleted, setShowDeleted] = useState(false);
+  const [showTrialsOnly, setShowTrialsOnly] = useState(false);
   const [showTeachersWithoutAppointments, setShowTeachersWithoutAppointments] =
     useState(false);
   const [teacherFilter, setTeacherFilter] = useState('');
@@ -151,11 +153,19 @@ export const AppointmentsAdminPanel = () => {
     endOfDay.setHours(26, 59, 59, 999);
 
     const studentAppointments = await axios.get('/appointments/student', {
-      params: {
-        leadId: leadId,
-        start: startOfRange,
-        end: endOfDay,
-      },
+      params: showTrialsOnly
+        ? {
+            leadId: leadId,
+            start: startOfRange,
+            end: endOfDay,
+            IsTrial: true,
+          }
+        : {
+            leadId: leadId,
+            start: startOfRange,
+            end: endOfDay,
+            IsTrial: false,
+          },
     });
 
     setChosenTeacher(
@@ -228,6 +238,18 @@ export const AppointmentsAdminPanel = () => {
                   />
                 </CheckboxLabel>
                 <CheckboxLabel>
+                  Показати лише пробні записи
+                  <CheckboxInput
+                    type="checkbox"
+                    name="showTrialsOnly"
+                    id="showTrialsOnly"
+                    checked={showTrialsOnly}
+                    onChange={() =>
+                      setShowTrialsOnly(setShowTrialsOnly => !setShowTrialsOnly)
+                    }
+                  />
+                </CheckboxLabel>
+                <CheckboxLabel>
                   Показати тічерів без актуальних записів
                   <CheckboxInput
                     type="checkbox"
@@ -259,6 +281,8 @@ export const AppointmentsAdminPanel = () => {
                 <UserHeadCell>Очікує</UserHeadCell>
                 <UserHeadCell>Проведено</UserHeadCell>
                 <UserHeadCell>Не проведено</UserHeadCell>
+                {showDeleted && <UserHeadCell>Видалено</UserHeadCell>}
+                {showTrialsOnly && <UserHeadCell>Продажів</UserHeadCell>}
                 <UserHeadCell>Сума студентів</UserHeadCell>
                 <UserHeadCell>Записані студенти</UserHeadCell>
               </UserDBRow>
@@ -282,9 +306,17 @@ export const AppointmentsAdminPanel = () => {
                   .filter(teacher =>
                     showTeachersWithoutAppointments
                       ? teacher
+                      : showTrialsOnly
+                      ? appointments
+                          .filter(appointment => appointment.IsTrial)
+                          .some(
+                            appointment =>
+                              appointment.teacherId === String(teacher.altegioId) &&
+                              !appointment.isDeleted
+                          )
                       : appointments.some(
                           appointment =>
-                            Number(appointment.teacherId) === teacher.altegioId &&
+                            appointment.teacherId === String(teacher.altegioId) &&
                             !appointment.isDeleted
                         )
                   )
@@ -311,6 +343,9 @@ export const AppointmentsAdminPanel = () => {
                       </BodyCell>
                       {(() => {
                         const filteredAppointments = appointments
+                          .filter(appointment =>
+                            showTrialsOnly ? appointment.IsTrial : !appointment.IsTrial
+                          )
                           .filter(appointment =>
                             showDeleted
                               ? appointment.teacherId === String(teacher.altegioId)
@@ -339,6 +374,12 @@ export const AppointmentsAdminPanel = () => {
                         const noShowAppointments = filteredAppointments.filter(
                           appointment => appointment.status === '-1'
                         );
+                        const deletedAppointments = filteredAppointments.filter(
+                          appointment => appointment.isDeleted === true
+                        );
+                        const courseSoldAppointments = filteredAppointments.filter(
+                          appointment => appointment.leadPurchasedCourse === true
+                        );
 
                         return (
                           <>
@@ -354,6 +395,16 @@ export const AppointmentsAdminPanel = () => {
                             <BodyCell componentWidth="7em">
                               {noShowAppointments.length}
                             </BodyCell>
+                            {showDeleted && (
+                              <BodyCell componentWidth="7em">
+                                {deletedAppointments.length}
+                              </BodyCell>
+                            )}
+                            {showTrialsOnly && (
+                              <BodyCell componentWidth="7em">
+                                {courseSoldAppointments.length}
+                              </BodyCell>
+                            )}
                             <BodyCell componentWidth="6em">
                               {
                                 [
@@ -376,6 +427,11 @@ export const AppointmentsAdminPanel = () => {
                                 <AppointmentSpan componentWidth="6em">
                                   Записів
                                 </AppointmentSpan>
+                                {showTrialsOnly && (
+                                  <AppointmentSpan componentWidth="8em">
+                                    Курс придбано
+                                  </AppointmentSpan>
+                                )}
                               </HeaderCellBody>
                               {[
                                 ...new Map(
@@ -445,6 +501,19 @@ export const AppointmentsAdminPanel = () => {
                                       ).length
                                     }
                                   </AppointmentSpan>
+                                  {showTrialsOnly && (
+                                    <AppointmentSpan componentWidth="8em">
+                                      {filteredAppointments.some(
+                                        studentAppointment =>
+                                          studentAppointment.leadPurchasedCourse &&
+                                          appointment.leadId === studentAppointment.leadId
+                                      ) ? (
+                                        <PurchasedCourse>+</PurchasedCourse>
+                                      ) : (
+                                        ''
+                                      )}
+                                    </AppointmentSpan>
+                                  )}
                                 </AppointmentBody>
                               ))}
                             </AppointmentCell>
@@ -464,6 +533,7 @@ export const AppointmentsAdminPanel = () => {
               closeStudentAppointments={closeStudentAppointments}
               teachers={teachers}
               chosenTeacher={chosenTeacher}
+              showTrialsOnly={showTrialsOnly}
             />
           </Backdrop>
         )}

--- a/src/pages/Streams/AppointmentsAdminPanel/AppointmentsAdminPanel.styled.js
+++ b/src/pages/Streams/AppointmentsAdminPanel/AppointmentsAdminPanel.styled.js
@@ -134,7 +134,7 @@ export const AppointmentModal = styled.div`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 60vw;
+  width: 80vw;
   min-height: 500px;
   max-height: 60vh;
   background-color: #fff;
@@ -160,6 +160,16 @@ export const StudentInfoText = styled.p`
 
 export const StudentInfoTextHighlight = styled.span`
   font-weight: 700;
+`;
+
+export const StudentCoursePurchased = styled.span`
+  &.yes {
+    color: green;
+  }
+
+  &.no {
+    color: red;
+  }
 `;
 
 export const StudentAppointmentBox = styled.div`
@@ -214,4 +224,11 @@ export const StudentAppointmentBody = styled.p`
     background-color: #000;
     display: ${props => (props.deleted ? 'block' : 'none')};
   }
+`;
+
+export const PurchasedCourse = styled.span`
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 16px;
+  color: green;
 `;


### PR DESCRIPTION
Introduces a 'Show Trials Only' filter to the admin panel, allowing users to view only trial appointments. Displays course purchase status and details for students in trial mode, adds related UI elements and styles, and updates appointment and teacher filtering logic accordingly.