### PR TITLE
Add overdue feedback indicator and student filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ap-education",
-  "version": "1.0.64.22.4",
+  "version": "1.0.64.23",
   "private": true,
   "homepage": "https://academy.ap.education/",
   "dependencies": {

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -508,11 +508,6 @@ const TeacherPageSpeaking = lazy(() =>
     /* webpackChunkName: "Speaking Teacher Page" */ '../pages/TeacherPage/TeacherPageSpeaking'
   )
 );
-const TeacherPageSpeaking13 = lazy(() =>
-  import(
-    /* webpackChunkName: "Speaking Course 13 Teacher Page" */ '../pages/TeacherPage/TeacherPageSpeaking13'
-  )
-);
 const FormsLinkTree = lazy(() =>
   import(
     /* webpackChunkName: "Forms Linktree Page" */ '../pages/FormsLinkTree/FormsLinkTree'
@@ -731,7 +726,11 @@ export const App = () => {
             />
             <Route path="speaking/:slug" element={<SpeakingVideoRoom />} noindex={true} />
           </Route>
-          <Route path="speaking/admin/:room" element={<SpeakingAdminPanelNew />} noindex={true} />
+          <Route
+            path="speaking/admin/:room"
+            element={<SpeakingAdminPanelNew />}
+            noindex={true}
+          />
           <Route path="end-call" element={<EndCall />} noindex={true} />
           <Route path="end-call-pl" element={<EndCallPl />} noindex={true} />
           <Route path="my-ap" element={<MyAP />} noindex={true} />
@@ -1065,7 +1064,6 @@ export const App = () => {
             <Route path="a2sc" element={<TeacherPageSpeaking />} noindex={true} />
             <Route path="b1sc" element={<TeacherPageSpeaking />} noindex={true} />
             <Route path="b2sc" element={<TeacherPageSpeaking />} noindex={true} />
-            <Route path="13" element={<TeacherPageSpeaking13 />} noindex={true} />
             <Route path="c1sc" element={<TeacherPageSpeaking />} noindex={true} />
             <Route path="dea0sc" element={<TeacherPageSpeaking />} noindex={true} />
             <Route path="dea0_2sc" element={<TeacherPageSpeaking />} noindex={true} />

--- a/src/pages/Streams/TeacherAdminPanel/TeacherAdminPanel.styled.js
+++ b/src/pages/Streams/TeacherAdminPanel/TeacherAdminPanel.styled.js
@@ -203,6 +203,8 @@ export const Feedback = styled.p`
   text-align: start;
   white-space: pre-wrap;
   word-wrap: break-word;
+  position: relative;
+  z-index: -1;
 
   &:not(:last-child) {
     padding-bottom: 3px;
@@ -212,6 +214,17 @@ export const Feedback = styled.p`
 
   &.full {
     max-width: 85vw;
+  }
+
+  &::after {
+    content: '${props => (props.isOverdue ? ' ПРОТЕРМІНОВАНО ' : undefined)}';
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 3;
+    font-size: 10px;
+    color: red;
+    font-weight: 700;
   }
 `;
 

--- a/src/pages/Streams/TeacherAdminPanel/TeacherControlPageDe.jsx
+++ b/src/pages/Streams/TeacherAdminPanel/TeacherControlPageDe.jsx
@@ -191,6 +191,7 @@ const TeacherControlPageDe = () => {
                         position: 'absolute',
                         zIndex: '2',
                         top: '36px',
+                        backgroundColor: 'white',
                       }),
                       dropdownIndicator: baseStyles => ({
                         ...baseStyles,
@@ -219,6 +220,7 @@ const TeacherControlPageDe = () => {
                         position: 'absolute',
                         zIndex: '2',
                         top: '36px',
+                        backgroundColor: 'white',
                       }),
                       dropdownIndicator: baseStyles => ({
                         ...baseStyles,
@@ -284,7 +286,10 @@ const TeacherControlPageDe = () => {
                         )
                         .flatMap(user =>
                           user.feedback.map(
-                            feedbackObj => `для ${user.name}) ${feedbackObj.text}`
+                            feedbackObj =>
+                              `для ${user.name}) ${
+                                feedbackObj.isOverdue ? 'ПРОТЕРМІНОВАНО' : ''
+                              } ${feedbackObj.text}`
                           )
                         )
                         .sort((a, b) => {
@@ -307,13 +312,20 @@ const TeacherControlPageDe = () => {
                           return parsedDateB.localeCompare(parsedDateA); // Sort in descending order
                         })
                         .map((text, i) => (
-                          <Feedback className={fullReviews && 'full'} key={i}>
+                          <Feedback
+                            className={fullReviews && 'full'}
+                            key={i}
+                            isOverdue={text.includes('ПРОТЕРМІНОВАНО')}
+                          >
                             {!fullReviews
                               ? `(Відгук від ${text.match(regex)} ${text.slice(
                                   0,
                                   200
-                                )}...`
-                              : `(Відгук від ${text.match(regex)} ${text}`}
+                                )}...`.replace('ПРОТЕРМІНОВАНО', '')
+                              : `(Відгук від ${text.match(regex)} ${text}`.replace(
+                                  'ПРОТЕРМІНОВАНО',
+                                  ''
+                                )}
                           </Feedback>
                         ))}
                     </UserCell>

--- a/src/pages/Streams/TeacherAdminPanel/TeacherControlPageEn.jsx
+++ b/src/pages/Streams/TeacherAdminPanel/TeacherControlPageEn.jsx
@@ -39,7 +39,7 @@ const TeacherControlPageEn = () => {
   const [month, setMonth] = useState(new Date(Date.now()).getMonth() + 1);
   const [year, setYear] = useState(new Date(Date.now()).getFullYear());
 
-const yearOptions = [
+  const yearOptions = [
     { label: '2024', value: '2024' },
     { label: '2025', value: '2025' },
     { label: '2026', value: '2026' },
@@ -191,6 +191,7 @@ const yearOptions = [
                         position: 'absolute',
                         zIndex: '2',
                         top: '36px',
+                        backgroundColor: 'white',
                       }),
                       dropdownIndicator: (baseStyles, state) => ({
                         ...baseStyles,
@@ -219,6 +220,7 @@ const yearOptions = [
                         position: 'absolute',
                         zIndex: '2',
                         top: '36px',
+                        backgroundColor: 'white',
                       }),
                       dropdownIndicator: (baseStyles, state) => ({
                         ...baseStyles,
@@ -284,7 +286,10 @@ const yearOptions = [
                         )
                         .flatMap(user =>
                           user.feedback.map(
-                            feedbackObj => `для ${user.name}) ${feedbackObj.text}`
+                            feedbackObj =>
+                              `для ${user.name}) ${
+                                feedbackObj.isOverdue ? 'ПРОТЕРМІНОВАНО' : ''
+                              } ${feedbackObj.text}`
                           )
                         )
                         .sort((a, b) => {
@@ -307,13 +312,20 @@ const yearOptions = [
                           return parsedDateB.localeCompare(parsedDateA); // Sort in descending order
                         })
                         .map((text, i) => (
-                          <Feedback className={fullReviews && 'full'} key={i}>
+                          <Feedback
+                            className={fullReviews && 'full'}
+                            key={i}
+                            isOverdue={text.includes('ПРОТЕРМІНОВАНО')}
+                          >
                             {!fullReviews
                               ? `(Відгук від ${text.match(regex)} ${text.slice(
                                   0,
                                   200
-                                )}...`
-                              : `(Відгук від ${text.match(regex)} ${text}`}
+                                )}...`.replace('ПРОТЕРМІНОВАНО', '')
+                              : `(Відгук від ${text.match(regex)} ${text}`.replace(
+                                  'ПРОТЕРМІНОВАНО',
+                                  ''
+                                )}
                           </Feedback>
                         ))}
                     </UserCell>

--- a/src/pages/Streams/TeacherAdminPanel/TeacherControlPagePl.jsx
+++ b/src/pages/Streams/TeacherAdminPanel/TeacherControlPagePl.jsx
@@ -191,6 +191,7 @@ const TeacherControlPagePl = () => {
                         position: 'absolute',
                         zIndex: '2',
                         top: '36px',
+                        backgroundColor: 'white',
                       }),
                       dropdownIndicator: baseStyles => ({
                         ...baseStyles,
@@ -219,6 +220,7 @@ const TeacherControlPagePl = () => {
                         position: 'absolute',
                         zIndex: '2',
                         top: '36px',
+                        backgroundColor: 'white',
                       }),
                       dropdownIndicator: baseStyles => ({
                         ...baseStyles,
@@ -284,7 +286,10 @@ const TeacherControlPagePl = () => {
                         )
                         .flatMap(user =>
                           user.feedback.map(
-                            feedbackObj => `для ${user.name}) ${feedbackObj.text}`
+                            feedbackObj =>
+                              `для ${user.name}) ${
+                                feedbackObj.isOverdue ? 'ПРОТЕРМІНОВАНО' : ''
+                              } ${feedbackObj.text}`
                           )
                         )
                         .sort((a, b) => {
@@ -307,13 +312,20 @@ const TeacherControlPagePl = () => {
                           return parsedDateB.localeCompare(parsedDateA); // Sort in descending order
                         })
                         .map((text, i) => (
-                          <Feedback className={fullReviews && 'full'} key={i}>
+                          <Feedback
+                            className={fullReviews && 'full'}
+                            key={i}
+                            isOverdue={text.includes('ПРОТЕРМІНОВАНО')}
+                          >
                             {!fullReviews
                               ? `(Відгук від ${text.match(regex)} ${text.slice(
                                   0,
                                   200
-                                )}...`
-                              : `(Відгук від ${text.match(regex)} ${text}`}
+                                )}...`.replace('ПРОТЕРМІНОВАНО', '')
+                              : `(Відгук від ${text.match(regex)} ${text}`.replace(
+                                  'ПРОТЕРМІНОВАНО',
+                                  ''
+                                )}
                           </Feedback>
                         ))}
                     </UserCell>

--- a/src/pages/TeacherPage/TeacherPage.styled.js
+++ b/src/pages/TeacherPage/TeacherPage.styled.js
@@ -335,3 +335,11 @@ export const InputButtonBox = styled.div`
     pointer-events: none;
   }
 `;
+
+export const SpeakingStudentFilterInput = styled.input`
+  width: 450px;
+  max-height: 38px;
+
+  padding: 10px;
+  border: 2px solid var(--main-color);
+`;

--- a/src/pages/TeacherPage/TeacherPageSpeaking.jsx
+++ b/src/pages/TeacherPage/TeacherPageSpeaking.jsx
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { Backdrop } from 'components/LeadForm/Backdrop/Backdrop.styled';
 import { Loader } from 'components/SharedLayout/Loaders/Loader';
+import { CheckboxLabel } from 'pages/Streams/AppointmentsAdminPanel/AppointmentsAdminPanel.styled';
 import {
   UserCell,
   UserCellLeft,
@@ -12,9 +13,13 @@ import {
 } from 'pages/Streams/UserAdminPanel/UserAdminPanel.styled';
 import { useEffect, useRef, useState } from 'react';
 import { useLocation, useOutletContext } from 'react-router-dom';
-import { TeacherSpeakingDBSection, TeacherSpeakingDBTable } from './TeacherPage.styled';
-import { TeacherPageSpeakingEditForm } from './TeacherPageSpeakingEditForm/TeacherPageSpeakingEditForm';
 import { StudentChart } from './StudentChart/StudentChart';
+import {
+  SpeakingStudentFilterInput,
+  TeacherSpeakingDBSection,
+  TeacherSpeakingDBTable,
+} from './TeacherPage.styled';
+import { TeacherPageSpeakingEditForm } from './TeacherPageSpeakingEditForm/TeacherPageSpeakingEditForm';
 
 const TeacherPageSpeaking = () => {
   const location = useLocation().pathname.split('/speakings/')[1];
@@ -28,6 +33,7 @@ const TeacherPageSpeaking = () => {
   const [isStudentChartOpen, setIsStudentChartOpen] = useState(false);
   const linksRegex = /\b(?:https?|ftp):\/\/\S+\b/g;
   const [currentUser] = useOutletContext();
+  const [studentFilter, setStudentFilter] = useState('');
 
   const closeStudentEditForm = e => {
     setIsEditStudentFormOpen(false);
@@ -203,7 +209,18 @@ const TeacherPageSpeaking = () => {
   return (
     <TeacherSpeakingDBSection>
       <TeacherSpeakingDBTable>
-        <UserDBCaption>Список студентів, що відвідали заняття</UserDBCaption>
+        <UserDBCaption>
+          Список студентів, що відвідали заняття
+          <CheckboxLabel>
+            <SpeakingStudentFilterInput
+              type="text"
+              name="studentFilter"
+              value={studentFilter}
+              onChange={e => setStudentFilter(e.target.value)}
+              placeholder="Почніть вводити ім'я або прізвище студента..."
+            />
+          </CheckboxLabel>
+        </UserDBCaption>
         <thead>
           <UserDBRow>
             <UserHeadCell>№</UserHeadCell>
@@ -226,28 +243,38 @@ const TeacherPageSpeaking = () => {
           </UserDBRow>
         </thead>
         <tbody>
-          {users
-            .filter(user =>
-              page === 'deb2sc'
-                ? new Date() -
-                    new Date(changeDateFormat(user.visited[user.visited.length - 1])) <=
-                    4 * 86400000 &&
-                  (lang.current === user.lang ||
-                    user.lang.split('/').some(userLang => lang.current === userLang)) &&
-                  (user.course.includes('24') ||
-                    user.course
-                      .split('/')
-                      .some(usersCourse => usersCourse.includes('24')))
-                : new Date() -
-                    new Date(changeDateFormat(user.visited[user.visited.length - 1])) <=
-                    4 * 86400000 &&
-                  (lang === user.lang ||
-                    user.lang.split('/').some(userLang => lang.current === userLang)) &&
-                  (course.current === user.course ||
-                    user.course
-                      .split('/')
-                      .some(userCourse => course.current === userCourse))
-            )
+          {(() => {
+            return studentFilter
+              ? users.filter(user =>
+                  user.name
+                    .toLowerCase()
+                    .trim()
+                    .includes(studentFilter.toLowerCase().trim())
+                )
+              : users.filter(user =>
+                  page === 'deb2sc'
+                    ? new Date() - new Date(changeDateFormat(user.visited.at(-1))) <=
+                        4 * 86400000 &&
+                      (lang.current === user.lang ||
+                        user.lang
+                          .split('/')
+                          .some(userLang => lang.current === userLang)) &&
+                      (user.course.includes('24') ||
+                        user.course
+                          .split('/')
+                          .some(usersCourse => usersCourse.includes('24')))
+                    : new Date() - new Date(changeDateFormat(user.visited.at(-1))) <=
+                        4 * 86400000 &&
+                      (lang === user.lang ||
+                        user.lang
+                          .split('/')
+                          .some(userLang => lang.current === userLang)) &&
+                      (course.current === user.course ||
+                        user.course
+                          .split('/')
+                          .some(userCourse => course.current === userCourse))
+                );
+          })()
             .sort((a, b) => Intl.Collator('uk').compare(a.name, b.name))
             .map((user, i) => (
               <UserDBRow key={user._id}>

--- a/src/pages/TeacherPage/TeacherPageSpeakingEditForm/TeacherPageSpeakingEditForm.jsx
+++ b/src/pages/TeacherPage/TeacherPageSpeakingEditForm/TeacherPageSpeakingEditForm.jsx
@@ -161,6 +161,7 @@ export const TeacherPageSpeakingEditForm = ({
     activity: '',
     feedback: '',
     grade: '',
+    isOverdue: false,
   };
 
   const studentSchema = yup.object().shape({
@@ -173,6 +174,7 @@ export const TeacherPageSpeakingEditForm = ({
     activity: yup.number(),
     feedback: yup.string().required("Фідбек - обов'язкове поле, без нього ніяк"),
     grade: yup.number(),
+    isOverdue: yup.boolean(),
   });
 
   const validations = [
@@ -221,6 +223,7 @@ ${values.feedback}`,
         speaking: speakingValue,
         listening: listeningValue,
         grade: gradeValue,
+        isOverdue: new Date() - startDate > 4 * 86400000,
       },
     };
 


### PR DESCRIPTION
Introduces an 'overdue' indicator for feedback in teacher admin panels and edit forms, displaying a label when feedback is overdue. Adds a student name filter input to the speaking students list for easier searching. Also improves dropdown styling and removes unused code for the speaking course 13 teacher page.