### PR TITLE
Add radio filter for lesson type in admin panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ap-education",
-  "version": "1.0.64.25",
+  "version": "1.0.64.26",
   "private": true,
   "homepage": "https://academy.ap.education/",
   "dependencies": {

--- a/src/pages/Streams/AppointmentsAdminPanel/AppointmentStudentModal.jsx
+++ b/src/pages/Streams/AppointmentsAdminPanel/AppointmentStudentModal.jsx
@@ -198,7 +198,13 @@ export const AppointmentStudentModal = ({
                   deleted={appointment.isDeleted}
                 >
                   <AppointmentSpan componentWidth="6em">
-                    {appointment.appointmentId}
+                    <a
+                      href={`https://app.alteg.io/timetable/761978#open_modal_by_record_id=${appointment.appointmentId}`}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {appointment.appointmentId}
+                    </a>
                   </AppointmentSpan>
                   <AppointmentSpan componentWidth="8em">
                     {appointment.IsTrial ? 'Пробне' : 'Індивідуальне'}

--- a/src/pages/Streams/AppointmentsAdminPanel/AppointmentsAdminPanel.jsx
+++ b/src/pages/Streams/AppointmentsAdminPanel/AppointmentsAdminPanel.jsx
@@ -28,6 +28,8 @@ import {
   CheckboxLabel,
   HeaderCellBody,
   PurchasedCourse,
+  RadioGroup,
+  RadioLabel,
   TeacherFilterInput,
 } from './AppointmentsAdminPanel.styled';
 import { AppointmentStudentModal } from './AppointmentStudentModal';
@@ -237,18 +239,32 @@ export const AppointmentsAdminPanel = () => {
                     onChange={() => setShowDeleted(showDeleted => !showDeleted)}
                   />
                 </CheckboxLabel>
-                <CheckboxLabel>
-                  Показати лише пробні записи
-                  <CheckboxInput
-                    type="checkbox"
-                    name="showTrialsOnly"
-                    id="showTrialsOnly"
-                    checked={showTrialsOnly}
-                    onChange={() =>
-                      setShowTrialsOnly(setShowTrialsOnly => !setShowTrialsOnly)
-                    }
-                  />
-                </CheckboxLabel>
+                <RadioGroup>
+                  Показано записи лише на:
+                  <RadioLabel>
+                    пробні
+                    <CheckboxInput
+                      type="radio"
+                      name="lessonType"
+                      id="lessonTypeTrial"
+                      value="trial"
+                      checked={showTrialsOnly}
+                      onChange={e => setShowTrialsOnly(e.target.value === 'trial')}
+                    />
+                  </RadioLabel>
+                  <RadioLabel>
+                    індивідуальні
+                    <CheckboxInput
+                      type="radio"
+                      name="lessonType"
+                      id="lessonTypeIndividual"
+                      value="individual"
+                      checked={!showTrialsOnly}
+                      onChange={e => setShowTrialsOnly(e.target.value === 'trial')}
+                    />
+                  </RadioLabel>
+                </RadioGroup>
+
                 <CheckboxLabel>
                   Показати тічерів без актуальних записів
                   <CheckboxInput
@@ -275,8 +291,8 @@ export const AppointmentsAdminPanel = () => {
             <AppointmentHead>
               <UserDBRow>
                 <UserHeadCell>Ім'я</UserHeadCell>
-                <UserHeadCell>Altegio ID</UserHeadCell>
                 <UserHeadCell>CRM ID</UserHeadCell>
+                <UserHeadCell>Altegio ID</UserHeadCell>
                 <UserHeadCell>Сума записів</UserHeadCell>
                 <UserHeadCell>Очікує</UserHeadCell>
                 <UserHeadCell>Проведено</UserHeadCell>

--- a/src/pages/Streams/AppointmentsAdminPanel/AppointmentsAdminPanel.styled.js
+++ b/src/pages/Streams/AppointmentsAdminPanel/AppointmentsAdminPanel.styled.js
@@ -27,7 +27,6 @@ export const TeacherFilterInput = styled.input`
 export const CheckboxContainer = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: end;
   gap: 6px;
 `;
@@ -56,9 +55,22 @@ export const AppointmentHead = styled.thead`
   z-index: 1; */
 `;
 
+export const RadioGroup = styled.div`
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+`;
+
 export const CheckboxLabel = styled(Label)`
   flex-direction: row;
   margin-left: auto;
+`;
+
+export const RadioLabel = styled(Label)`
+  flex-direction: row;
+  width: auto;
 `;
 
 export const CheckboxInput = styled.input`


### PR DESCRIPTION
Replaces the 'show trials only' checkbox with radio buttons to filter between trial and individual lessons in the AppointmentsAdminPanel. Also updates the table header order and adds a link to Altegio appointment IDs in the student modal. Styling adjustments for new radio controls are included.