### PR TITLE
Fix percentage calculation in trials-only view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ap-education",
-  "version": "1.0.64.27",
+  "version": "1.0.64.27.1",
   "private": true,
   "homepage": "https://academy.ap.education/",
   "dependencies": {

--- a/src/pages/Streams/AppointmentsAdminPanel/AppointmentsAdminPanel.jsx
+++ b/src/pages/Streams/AppointmentsAdminPanel/AppointmentsAdminPanel.jsx
@@ -424,9 +424,11 @@ export const AppointmentsAdminPanel = () => {
                             )}
                             {showTrialsOnly && (
                               <BodyCell componentWidth="7em">
-                                {(courseSoldAppointments.length /
-                                  (completedAppointments.length || 1)) *
-                                  (100.0).toFixed(2)}
+                                {(
+                                  (courseSoldAppointments.length /
+                                    (completedAppointments.length || 1)) *
+                                  100.0
+                                ).toFixed(2)}
                                 %
                               </BodyCell>
                             )}


### PR DESCRIPTION
Corrected the calculation and formatting of the percentage value for course sold appointments in the trials-only view. The previous implementation incorrectly applied toFixed before multiplication, leading to inaccurate results.